### PR TITLE
Add option to clip osmpbf files with osmosis and osmconvert tools

### DIFF
--- a/.github/workflows/_tests.yml
+++ b/.github/workflows/_tests.yml
@@ -8,9 +8,11 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         include:
           - os: macos-latest
+            python-version: "3.11"
+          - os: windows-latest
             python-version: "3.11"
     env:
       OS: ${{ matrix.os }}

--- a/.github/workflows/_tests.yml
+++ b/.github/workflows/_tests.yml
@@ -8,11 +8,9 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
         include:
           - os: macos-latest
-            python-version: "3.11"
-          - os: windows-latest
             python-version: "3.11"
     env:
       OS: ${{ matrix.os }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `PbfFileClipper` for cutting bigger `osm.pbf` files into smaller sizes for faster operations. [#369](https://github.com/kraina-ai/srai/issues/369)
+- `PbfFileClipper` for cutting bigger `osm.pbf` files into smaller sizes for faster operations. Included clipping inside `PbfFileDownloader` for new bigger extracts sources. [#369](https://github.com/kraina-ai/srai/issues/369)
 
 ### Changed
 
@@ -17,11 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Refactored `OSMLoader`'s `GroupedOsmTagsFilter` features grouping to be faster by refactoring pandas operations [#354](https://github.com/srai-lab/srai/issues/354)
 - Sped up `VoronoiRegionalizer` by removing redundant intersection operations and vectorizing ecdf2geodetic calculations [#351](https://github.com/kraina-ai/srai/issues/351)
 - Sped up `ContextualCountEmbedder` by removing iteration over dataframe rows and vectorizing operations to work at a whole `numpy` array at once [#359](https://github.com/kraina-ai/srai/issues/359)
-- Added Geofabrik and OpenStreetMap.fr PBF extracts download services. Replaced default Protomaps service with Geofabrik index for PbfDownloader [#158](https://github.com/kraina-ai/srai/issues/158) [#366](https://github.com/kraina-ai/srai/issues/366)
+- Added Geofabrik and OpenStreetMap.fr PBF extracts download services. Added automatic switch from default `protomaps` download service to `geofabrik` on error. [#158](https://github.com/kraina-ai/srai/issues/158) [#366](https://github.com/kraina-ai/srai/issues/366)
 
 ### Deprecated
-
-- Usage of Protomaps download service, since the Protomaps Downloads service is being stopped. Related to [#366](https://github.com/kraina-ai/srai/issues/366)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `PbfFileClipper` for cutting bigger `osm.pbf` files into smaller sizes for faster operations. [#369](https://github.com/kraina-ai/srai/issues/369)
+
 ### Changed
 
 - Bumped `h3ronpy` library to `0.18.0` with added support for MacOS. Removed override with check for H3 operations if system is `darwin`. Changed internal API to use `ContainmentMode`.

--- a/srai/geometry.py
+++ b/srai/geometry.py
@@ -1,8 +1,10 @@
 """Utility geometry operations functions."""
+import hashlib
 from typing import List, Union
 
 import geopandas as gpd
 import pyproj
+import shapely.wkt as wktlib
 from functional import seq
 from shapely.geometry import MultiPolygon, Polygon
 from shapely.geometry.base import BaseGeometry, BaseMultipartGeometry
@@ -116,3 +118,11 @@ def merge_disjointed_gdf_geometries(gdf: gpd.GeoDataFrame) -> MultiPolygon:
         MultiPolygon: Merged polygon
     """
     return merge_disjointed_polygons(list(gdf.geometry))
+
+
+def get_geometry_hash(geometry: BaseGeometry) -> str:
+    """Generate SHA256 hash based on WKT representation of the polygon."""
+    wkt_string = wktlib.dumps(geometry)
+    h = hashlib.new("sha256")
+    h.update(wkt_string.encode())
+    return h.hexdigest()

--- a/srai/loaders/download.py
+++ b/srai/loaders/download.py
@@ -30,6 +30,7 @@ def download_file(
         headers={"User-Agent": "SRAI Python package (https://github.com/kraina-ai/srai)"},
         stream=True,
     )
+    resp.raise_for_status()
     total = int(resp.headers.get("content-length", 0))
     with open(fname, "wb") as file, tqdm(
         desc=fname.split("/")[-1],

--- a/srai/loaders/osm_loaders/openstreetmap_extracts.py
+++ b/srai/loaders/osm_loaders/openstreetmap_extracts.py
@@ -334,7 +334,7 @@ def _load_geofabrik_index() -> gpd.GeoDataFrame:
     gdf["area"] = gdf.geometry.area
     gdf.sort_values(by="area", ignore_index=True, inplace=True)
     gdf[[col for col in gdf.columns if col != "geometry" and col != "urls"]].to_csv(
-        "geofabrik_index.csv"
+        "cache/geofabrik_index.csv"
     )
     return gdf
 
@@ -354,7 +354,7 @@ def _load_openstreetmap_fr_index() -> gpd.GeoDataFrame:
     gdf["area"] = gdf.geometry.area
     gdf.sort_values(by="area", ignore_index=True, inplace=True)
     gdf[[col for col in gdf.columns if col != "geometry" and col != "urls"]].to_csv(
-        "osm_fr_index.csv"
+        "cache/osm_fr_index.csv"
     )
     return gdf
 

--- a/srai/loaders/osm_loaders/osm_pbf_loader.py
+++ b/srai/loaders/osm_loaders/osm_pbf_loader.py
@@ -37,8 +37,9 @@ class OSMPbfLoader(OSMLoader):
     def __init__(
         self,
         pbf_file: Optional[Union[str, Path]] = None,
-        download_source: PbfSourceLiteral = "geofabrik",
+        download_source: PbfSourceLiteral = "protomaps",
         download_directory: Union[str, Path] = "files",
+        switch_to_geofabrik_on_error: bool = True,
     ) -> None:
         """
         Initialize OSMPbfLoader.
@@ -48,15 +49,18 @@ class OSMPbfLoader(OSMLoader):
                 the loader. If not provided, it will be automatically downloaded for a given area.
                 Defaults to None.
             download_source (PbfSourceLiteral, optional): Source to use when downloading PBF files.
-                Can be ine of: `geofabrik`, `openstreetmap_fr`, `protomaps`.
-                Defaults to "geofabrik".
+                Can be one of: `geofabrik`, `openstreetmap_fr`, `protomaps`.
+                Defaults to "protomaps".
             download_directory (Union[str, Path], optional): Directory where to save the downloaded
-                `*.osm.pbf` files. Ignored if `pbf_file` is provided. Defaults to "files"
+                `*.osm.pbf` files. Ignored if `pbf_file` is provided. Defaults to "files".
+            switch_to_geofabrik_on_error (bool, optional): Flag whether to automatically
+                switch `download_source` to 'geofabrik' if error occures. Defaults to `True`.
         """
         import_optional_dependencies(dependency_group="osm", modules=["osmium"])
         self.pbf_file = pbf_file
         self.download_source = download_source
         self.download_directory = download_directory
+        self.switch_to_geofabrik_on_error = switch_to_geofabrik_on_error
 
     def load(
         self,
@@ -103,7 +107,9 @@ class OSMPbfLoader(OSMLoader):
             downloaded_pbf_files = {Path(self.pbf_file).name: [self.pbf_file]}
         else:
             downloaded_pbf_files = PbfFileDownloader(
-                source=self.download_source, download_directory=self.download_directory
+                download_source=self.download_source,
+                download_directory=self.download_directory,
+                switch_to_geofabrik_on_error=self.switch_to_geofabrik_on_error,
             ).download_pbf_files_for_regions_gdf(regions_gdf=area_wgs84)
 
         merged_tags = self._merge_osm_tags_filter(tags)

--- a/srai/loaders/osm_loaders/pbf_file_clipper.py
+++ b/srai/loaders/osm_loaders/pbf_file_clipper.py
@@ -8,12 +8,12 @@ import os
 import stat
 import tempfile
 import zipfile
+from pathlib import Path
 from sys import platform
 from typing import Sequence, Union
 
 import numpy as np
 import tqdm
-from pathlib2 import Path
 from shapely.geometry import MultiPolygon, Polygon
 
 from srai.geometry import get_geometry_hash

--- a/srai/loaders/osm_loaders/pbf_file_clipper.py
+++ b/srai/loaders/osm_loaders/pbf_file_clipper.py
@@ -130,7 +130,7 @@ class PbfFileClipper:
 
             # if single file - copy it
             if len(clipped_pbf_files_list) == 1:
-                if platform in ("linux", "linux2"):
+                if tmp_file_extension == "o5m":
                     self._convert_o5m_to_pbf(clipped_pbf_files_list[0], final_osm_path)
                 else:
                     Path(clipped_pbf_files_list[0]).rename(final_osm_path)

--- a/srai/loaders/osm_loaders/pbf_file_clipper.py
+++ b/srai/loaders/osm_loaders/pbf_file_clipper.py
@@ -1,0 +1,245 @@
+"""
+PBF File Clipper.
+
+This module contains a clipper capable of clipping a PBF file to a smaller size using osmconvert or
+osmosis CLI tools.
+"""
+import os
+import stat
+import tempfile
+import zipfile
+from sys import platform
+from typing import Sequence, Union
+
+import numpy as np
+import tqdm
+from pathlib2 import Path
+from shapely.geometry import MultiPolygon, Polygon
+
+from srai.geometry import get_geometry_hash
+from srai.loaders.download import download_file
+
+
+class PbfFileClipper:
+    """
+    PbfFileClipper.
+
+    PBF(Protocolbuffer Binary Format)[1] file clipper is a tool
+    capable of clipping `*.osm.pbf` files with OSM data for a given area to make it smaller.
+
+    Class will automatically download those CLI tools and execute them from Python code.
+
+    This clipper uses two tools to clip a PBF file for a given region:
+     - Osmconvert [2] - used on Linux systems
+     - Osmosis [3] - used on OS X and Windows systems
+
+    References:
+        1. https://wiki.openstreetmap.org/wiki/PBF_Format
+        2. https://wiki.openstreetmap.org/wiki/Osmconvert
+        3. https://wiki.openstreetmap.org/wiki/Osmosis
+    """
+
+    def __init__(self, working_directory: Union[str, Path] = "files") -> None:
+        """
+        Initialize PbfFileClipper.
+
+        Args:
+            working_directory (Union[str, Path], optional): Directory where to save
+                the parsed `*.osm.pbf` files. Defaults to "files".
+        """
+        self.working_directory = Path(working_directory)
+
+        # Tools for clipping OSM files into smaller regions
+        # osmconvert is faster, but works on Linux
+        self.OSMCONVERT_PATH = (self.working_directory / "osmconvert_tool/osmconvert").as_posix()
+        # osmosis is slower, but also works on Mac OS
+        self.OSMOSIS_DIRECTORY_PATH = (self.working_directory / "osmosis_tool").as_posix()
+        self.OSMOSIS_EXECUTABLE_PATH = (
+            self.working_directory / "osmosis_tool/bin/osmosis"
+        ).as_posix()
+
+    def clip_pbf_file(
+        self,
+        geometry: Polygon,
+        pbf_files: Sequence[Union[str, "os.PathLike[str]"]],
+    ) -> Path:
+        """
+        Clip a list of PBF files using a given geometry and merge them into a single file.
+
+        Args:
+            geometry (Polygon): Geometry to be used for clipping.
+            pbf_files (Sequence[Union[str, os.PathLike[str]]]): List of PBF files to be processed.
+
+        Raises:
+            RuntimeError: If system is unrecognized (not one of linux, linux2, darwin or win32)
+
+        Returns:
+            Path: Location of merged PBF file.
+        """
+        geometry_hash = get_geometry_hash(geometry)
+        final_osm_path = (self.working_directory.resolve() / f"{geometry_hash}.osm.pbf").as_posix()
+
+        if Path(final_osm_path).exists():
+            return Path(final_osm_path)
+
+        with tempfile.TemporaryDirectory() as tmp_dir_name:
+            tmp_dir_path = Path(tmp_dir_name)
+
+            poly_path = (tmp_dir_path.resolve() / f"poly_files/{geometry_hash}.poly").as_posix()
+
+            # create poly file
+            self._generate_poly_file(geometry, poly_path)
+
+            if platform in ("linux", "linux2"):
+                self._download_osmconvert_tool()
+            elif platform in ("darwin", "win32"):
+                self._download_osmosis_tool()
+            else:
+                raise RuntimeError(f"Unrecognized system platform: {platform}")
+
+            # clip all pbf_files in temp directory
+            clipped_pbf_files_set = set()
+            for pbf_file_path in pbf_files:
+                pbf_file_path_posix = Path(pbf_file_path).as_posix()
+                pbf_file_name = Path(pbf_file_path).stem.split(".")[0]
+                osm_path = (
+                    tmp_dir_path.resolve() / f"pbf_files/{pbf_file_name}_{geometry_hash}.osm.pbf"
+                ).as_posix()
+
+                clipped_pbf_files_set.add(osm_path)
+
+                if Path(osm_path).exists():
+                    continue
+
+                if platform in ("linux", "linux2"):
+                    self._clip_pbf_with_osmconvert(pbf_file_path_posix, poly_path, osm_path)
+                elif platform in ("darwin", "win32"):
+                    self._clip_pbf_with_osmosis(pbf_file_path_posix, poly_path, osm_path)
+                else:
+                    raise RuntimeError(f"Unrecognized system platform: {platform}")
+
+            clipped_pbf_files_list = list(clipped_pbf_files_set)
+
+            # if single file - copy it
+            if len(clipped_pbf_files_list) == 1:
+                Path(clipped_pbf_files_list[0]).rename(final_osm_path)
+            # merge all of the files and copy it
+            else:
+                if platform in ("linux", "linux2"):
+                    self._merge_pbfs_with_osmconvert(clipped_pbf_files_list, final_osm_path)
+                elif platform in ("darwin", "win32"):
+                    self._merge_pbfs_with_osmosis(clipped_pbf_files_list, final_osm_path)
+                else:
+                    raise RuntimeError(f"Unrecognized system platform: {platform}")
+
+        return Path(final_osm_path)
+
+    def _generate_poly_file(self, geometry: Union[Polygon, MultiPolygon], poly_file: str) -> None:
+        """
+        This function will create the .poly files from the nuts shapefile.
+
+        These.poly files are used to extract data from the openstreetmap files. This function is
+        adapted from the OSMPoly function in QGIS.
+        """
+        Path(poly_file).parent.mkdir(parents=True, exist_ok=True)
+
+        # this will create a list of the different subpolygons
+        if geometry.geom_type == "MultiPolygon":
+            polygons = geometry.geoms
+
+        # the list will be lenght 1 if it is just one polygon
+        elif geometry.geom_type == "Polygon":
+            polygons = [geometry]
+
+        # start writing the .poly file
+        f = open(poly_file, "w")
+        f.write("polygon\n")
+
+        i = 0
+
+        # loop over the different polygons, get their exterior and write the
+        # coordinates of the ring to the .poly file
+        for polygon in polygons:
+            polygon_coords = np.array(polygon.exterior.coords)
+
+            j = 0
+            f.write(str(i) + "\n")
+
+            for ring in polygon_coords:
+                j = j + 1
+                f.write("    " + str(ring[0]) + "     " + str(ring[1]) + "\n")
+
+            i = i + 1
+            # close the ring of one subpolygon if done
+            f.write("END\n")
+
+        # close the file when done
+        f.write("END\n")
+        f.close()
+
+    def _download_osmconvert_tool(self) -> None:
+        file_path = Path(self.OSMCONVERT_PATH)
+        if not file_path.exists():
+            tool_url = "http://m.m.i24.cc/osmconvert64"
+            download_file(tool_url, self.OSMCONVERT_PATH)
+
+            # make it executable
+            file_path.chmod(file_path.stat().st_mode | stat.S_IEXEC)
+
+    def _download_osmosis_tool(self) -> None:
+        zip_path = (Path(self.OSMOSIS_DIRECTORY_PATH) / "osmosis.zip").as_posix()
+        file_path = Path(self.OSMOSIS_EXECUTABLE_PATH)
+        if not file_path.exists():
+            tool_url = "https://github.com/openstreetmap/osmosis/releases/download/0.48.3/osmosis-0.48.3.zip"
+            download_file(tool_url, zip_path)
+
+            with zipfile.ZipFile(zip_path, "r") as zf:
+                for member in tqdm(zf.infolist(), desc=""):
+                    try:
+                        zf.extract(member, self.OSMOSIS_DIRECTORY_PATH)
+                    except zipfile.error:
+                        pass
+
+            # make it executable
+            file_path.chmod(file_path.stat().st_mode | stat.S_IEXEC)
+
+    def _clip_pbf_with_osmconvert(
+        self, source_pbf_path: str, poly_file_path: str, output_pbf_path: str
+    ) -> None:
+        """Wrapper over osmconvert CLI tool."""
+        Path(output_pbf_path).parent.mkdir(parents=True, exist_ok=True)
+        os.system(
+            "{}  {} -B={} --complete-ways --complete-multipolygons -o={}".format(
+                self.OSMCONVERT_PATH, source_pbf_path, poly_file_path, output_pbf_path
+            )
+        )
+
+    def _clip_pbf_with_osmosis(
+        self, source_pbf_path: str, poly_file_path: str, output_pbf_path: str
+    ) -> None:
+        """Wrapper over osmosis CLI tool."""
+        Path(output_pbf_path).parent.mkdir(parents=True, exist_ok=True)
+        os.system(
+            '{} --read-pbf file="{}" --bounding-polygon file="{}" --write-pbf file="{}"'.format(
+                self.OSMOSIS_EXECUTABLE_PATH, source_pbf_path, poly_file_path, output_pbf_path
+            )
+        )
+
+    # osmconvert region1.pbf --out-o5m | osmconvert - region2.pbf -o=all.pbf
+    def _merge_pbfs_with_osmconvert(self, pbf_paths: Sequence[str], output_pbf_path: str) -> None:
+        Path(output_pbf_path).parent.mkdir(parents=True, exist_ok=True)
+        current_first_pbf_path = pbf_paths[0]
+        for current_second_pbf_path in pbf_paths[1:]:
+            command = (
+                f"{self.OSMCONVERT_PATH} {current_first_pbf_path} --out-o5m | "
+                f"{self.OSMCONVERT_PATH} - {current_second_pbf_path} -o={output_pbf_path}"
+            )
+            os.system(command)
+            current_first_pbf_path = output_pbf_path
+
+    # osmosis --rb file1.osm --rb file2.osm --merge --wb merged.osm
+    def _merge_pbfs_with_osmosis(self, pbf_paths: Sequence[str], output_pbf_path: str) -> None:
+        Path(output_pbf_path).parent.mkdir(parents=True, exist_ok=True)
+        joined_files = " ".join([f"--rb {pbf_path}" for pbf_path in pbf_paths])
+        command = f"{self.OSMOSIS_EXECUTABLE_PATH} {joined_files} --merge --wb {output_pbf_path}"
+        os.system(command)

--- a/srai/loaders/osm_loaders/pbf_file_clipper.py
+++ b/srai/loaders/osm_loaders/pbf_file_clipper.py
@@ -130,7 +130,10 @@ class PbfFileClipper:
 
             # if single file - copy it
             if len(clipped_pbf_files_list) == 1:
-                Path(clipped_pbf_files_list[0]).rename(final_osm_path)
+                if platform in ("linux", "linux2"):
+                    self._convert_o5m_to_pbf(clipped_pbf_files_list[0], final_osm_path)
+                else:
+                    Path(clipped_pbf_files_list[0]).rename(final_osm_path)
             # merge all of the files and copy it
             else:
                 merge_function(clipped_pbf_files_list, final_osm_path_alphanumeric_safe)
@@ -248,4 +251,9 @@ class PbfFileClipper:
         command = (
             f"{self.OSMOSIS_EXECUTABLE_PATH} {joined_files} {merge_commands} --wb {output_pbf_path}"
         )
+        os.system(command)
+
+    def _convert_o5m_to_pbf(self, o5m_path: Sequence[str], output_pbf_path: str) -> None:
+        Path(output_pbf_path).parent.mkdir(parents=True, exist_ok=True)
+        command = f"{self.OSMCONVERT_PATH} {o5m_path} -o={output_pbf_path}"
         os.system(command)

--- a/srai/loaders/osm_loaders/pbf_file_downloader.py
+++ b/srai/loaders/osm_loaders/pbf_file_downloader.py
@@ -3,7 +3,6 @@ PBF File Downloader.
 
 This module contains a downloader capable of downloading a PBF file from a free Protomaps service.
 """
-import hashlib
 import json
 import warnings
 from pathlib import Path
@@ -12,7 +11,6 @@ from typing import Any, Callable, Dict, Hashable, List, Literal, Sequence, Union
 
 import geopandas as gpd
 import requests
-import shapely.wkt as wktlib
 import topojson as tp
 from shapely.geometry import Polygon, mapping
 from shapely.geometry.base import BaseGeometry, BaseMultipartGeometry
@@ -23,6 +21,7 @@ from srai.geometry import (
     buffer_geometry,
     flatten_geometry,
     flatten_geometry_series,
+    get_geometry_hash,
     remove_interiors,
 )
 from srai.loaders import download_file
@@ -204,7 +203,7 @@ class PbfFileDownloader:
         Returns:
             Path: Path to a downloaded `*.osm.pbf` file.
         """
-        geometry_hash = self._get_geometry_hash(polygon)
+        geometry_hash = get_geometry_hash(polygon)
         pbf_file_path = Path(self.download_directory).resolve() / f"{geometry_hash}.osm.pbf"
 
         if not pbf_file_path.exists():  # pragma: no cover
@@ -343,10 +342,3 @@ class PbfFileDownloader:
             simplified_polygon = polygon.minimum_rotated_rectangle
 
         return simplified_polygon
-
-    def _get_geometry_hash(self, geometry: BaseGeometry) -> str:
-        """Generate SHA256 hash based on WKT representation of the polygon."""
-        wkt_string = wktlib.dumps(geometry)
-        h = hashlib.new("sha256")
-        h.update(wkt_string.encode())
-        return h.hexdigest()

--- a/tests/loaders/osm_loaders/test_osm_pbf_loader.py
+++ b/tests/loaders/osm_loaders/test_osm_pbf_loader.py
@@ -63,7 +63,7 @@ ut = TestCase()
 )
 def test_geometry_preparing(test_polygon: BaseGeometry):
     """Test proper geometry preparing in `PbfFileDownloader`."""
-    downloader = PbfFileDownloader()
+    downloader = PbfFileDownloader(source="protomaps")
     prepared_polygon = downloader._prepare_polygon_for_download(test_polygon)
 
     assert len(prepared_polygon.exterior.coords) <= 1000
@@ -148,7 +148,9 @@ def test_pbf_downloading(test_polygon: BaseGeometry, test_file_names: List[str])
         index=gpd.pd.Index(name=REGIONS_INDEX, data=[1]),
         crs=WGS84_CRS,
     )
-    downloader = PbfFileDownloader(download_directory=Path(__file__).parent / "test_files")
+    downloader = PbfFileDownloader(
+        source="protomaps", download_directory=Path(__file__).parent / "test_files"
+    )
     files = downloader.download_pbf_files_for_regions_gdf(regions_gdf)
     file_names = [path.name for path in files[1]]
     assert set(file_names) == set(test_file_names)
@@ -228,7 +230,7 @@ def test_pbf_handler_geometry_filtering():  # type: ignore
             None,
             HEX2VEC_FILTER,
             "geofabrik",
-            398,
+            397,
             12,
             [
                 "amenity",

--- a/tests/loaders/osm_loaders/test_osm_pbf_loader.py
+++ b/tests/loaders/osm_loaders/test_osm_pbf_loader.py
@@ -63,7 +63,10 @@ ut = TestCase()
 )
 def test_geometry_preparing(test_polygon: BaseGeometry):
     """Test proper geometry preparing in `PbfFileDownloader`."""
-    downloader = PbfFileDownloader(source="protomaps")
+    downloader = PbfFileDownloader(
+        download_source="protomaps",
+        switch_to_geofabrik_on_error=False,
+    )
     prepared_polygon = downloader._prepare_polygon_for_download(test_polygon)
 
     assert len(prepared_polygon.exterior.coords) <= 1000
@@ -85,7 +88,10 @@ def test_disallow_non_polygons(test_geometry: BaseGeometry, pbf_source: PbfSourc
             index=gpd.pd.Index(name=REGIONS_INDEX, data=[1]),
             crs=WGS84_CRS,
         )
-        downloader = PbfFileDownloader(source=pbf_source)
+        downloader = PbfFileDownloader(
+            download_source=pbf_source,
+            switch_to_geofabrik_on_error=False,
+        )
         downloader.download_pbf_files_for_regions_gdf(regions_gdf)
 
 
@@ -149,7 +155,9 @@ def test_pbf_downloading(test_polygon: BaseGeometry, test_file_names: List[str])
         crs=WGS84_CRS,
     )
     downloader = PbfFileDownloader(
-        source="protomaps", download_directory=Path(__file__).parent / "test_files"
+        download_source="protomaps",
+        download_directory=Path(__file__).parent / "test_files",
+        switch_to_geofabrik_on_error=False,
     )
     files = downloader.download_pbf_files_for_regions_gdf(regions_gdf)
     file_names = [path.name for path in files[1]]
@@ -289,7 +297,10 @@ def test_osm_pbf_loader(
     )
 
     loader = OSMPbfLoader(
-        pbf_file=pbf_file, download_directory=download_directory, download_source=pbf_source
+        pbf_file=pbf_file,
+        download_directory=download_directory,
+        download_source=pbf_source,
+        switch_to_geofabrik_on_error=False,
     )
     result = loader.load(area, tags=query)
 


### PR DESCRIPTION
To speed up the OSM PBF parsing operations, `osmconvert` and `osmosis` CLI tools have been integrated to automatically clip big PBF files from the Geofabrik service and make it easier to be loaded into memory,.