### PR TITLE
Possible GTFS Loader Bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Bugs in GTFS Loader: missing index name and NaN handling (implemented by [@zackAemmer](https://github.com/zackAemmer))
+
+
 ## [0.6.2] - 2023-12-28
 
 ### Added
@@ -24,8 +29,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
-
-- Bugs in GTFS Loader: missing index name and NaN handling (implemented by [@zackAemmer](https://github.com/zackAemmer))
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Bugs in GTFS Loader: missing index name and NaN handling (implemented by [@zackAemmer](https://github.com/zackAemmer))
+
 ### Security
 
 ## [0.6.1] - 2023-11-12

--- a/srai/embedders/gtfs2vec/embedder.py
+++ b/srai/embedders/gtfs2vec/embedder.py
@@ -186,7 +186,9 @@ class GTFS2VecEmbedder(Embedder):
             if column.startswith(GTFS2VEC_TRIPS_PREFIX):
                 agg_dict[column] = "sum"
             elif column.startswith(GTFS2VEC_DIRECTIONS_PREFIX):
-                agg_dict[column] = lambda x: len(reduce(set.union, x))
+                agg_dict[column] = lambda x: len(
+                    reduce(set.union, (val for val in x if not pd.isna(val)), set())
+                )
         return agg_dict
 
     def _normalize_columns_group(self, df: pd.DataFrame, columns: list[str]) -> pd.DataFrame:

--- a/srai/loaders/gtfs_loader.py
+++ b/srai/loaders/gtfs_loader.py
@@ -82,7 +82,7 @@ class GTFSLoader(Loader):
 
         result_gdf = result_gdf.merge(directions_df, how="left", on="stop_id")
 
-        result_gdf.index.name = None
+        result_gdf.index.name = "feature_id"
 
         return result_gdf
 

--- a/srai/loaders/gtfs_loader.py
+++ b/srai/loaders/gtfs_loader.py
@@ -18,7 +18,7 @@ import pandas as pd
 from shapely.geometry import Point
 
 from srai._optional import import_optional_dependencies
-from srai.constants import GEOMETRY_COLUMN, WGS84_CRS
+from srai.constants import FEATURES_INDEX, GEOMETRY_COLUMN, WGS84_CRS
 from srai.loaders import Loader
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -82,7 +82,7 @@ class GTFSLoader(Loader):
 
         result_gdf = result_gdf.merge(directions_df, how="left", on="stop_id")
 
-        result_gdf.index.name = "feature_id"
+        result_gdf.index.name = FEATURES_INDEX
 
         return result_gdf
 


### PR DESCRIPTION
Two possible bugs with loading and embedding GTFS data with GTFS2VEC loader and embedder:

- GTFSLoader uses df.pivot_table() to calculate the hourly embedding features from the static feed, which gives NaN values for hours/stops that don't have trips. For _load_trips this is filled with 0, but for _load_directions it should be an empty set, which as far as I can tell is not possible using df.pivot_table(). I handled this in GTFS2VecEmbedder by filtering NaN values as they are reduced. I also added an initial value because in a few cases there were hours with no trips at all.
- GTFS2VecEmbedder expects a features GeoDataFrame with an index that matches the joint GeoDataFrame, which is checked in _validate_indexes. GTFSLoader assigns the features GeoDataFrame an index of None. I just changed it to assign the FEATURE_ID constant.

```
from pathlib import Path
from srai.embedders import GTFS2VecEmbedder
from srai.joiners import IntersectionJoiner
from srai.loaders import GTFSLoader, download_file
from srai.neighbourhoods.h3_neighbourhood import H3Neighbourhood
from srai.regionalizers import H3Regionalizer
import geopandas as gpd
from shapely.geometry import Polygon
from srai.constants import WGS84_CRS

# Load GTFS from example notebook
wroclaw_gtfs = Path().resolve() / "files" / "example.zip"
gtfs_url = "https://transitfeeds.com/p/mpk-wroc-aw/663/20221221/download"
download_file(gtfs_url, wroclaw_gtfs.as_posix())
gtfs_loader = GTFSLoader()
features = gtfs_loader.load(wroclaw_gtfs)

print(features.index.name) # None

# Get H3 embedding regions covering the GTFS bounding box, join with features
min_x, min_y = features.geometry.bounds[['minx', 'miny']].min()
max_x, max_y = features.geometry.bounds[['maxx', 'maxy']].max()
geo = Polygon((
    (min_x, min_y),
    (min_x, max_y),
    (max_x, max_y),
    (max_x, min_y),
    (min_x, min_y)
))
area = gpd.GeoDataFrame(
    {'region_id': ['Wroclaw_test'],
     'geometry': [geo]},
     crs=WGS84_CRS
)
area.set_index('region_id', inplace=True)
regionalizer = H3Regionalizer(resolution=8)
joiner = IntersectionJoiner()
regions = regionalizer.transform(area)
neighbourhood = H3Neighbourhood(regions_gdf=regions)
joint = joiner.transform(regions, features)

# Fit embedder
embedder = GTFS2VecEmbedder(hidden_size=2, embedding_size=4)
embedder.fit(regions, features, joint)
embeddings_gtfs = embedder.transform(regions, features, joint)

# ValueError: features_gdf must have a named index.

features.index.name = 'feature_id'
embedder = GTFS2VecEmbedder(hidden_size=2, embedding_size=4)
embedder.fit(regions, features, joint)
embeddings_gtfs = embedder.transform(regions, features, joint)

# TypeError: descriptor 'union' for 'set' objects doesn't apply to a 'float' object
```