### PR TITLE
fix: set geofabrik as default download_source for OSMPbfLoader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- make geofabrik the default download source for OSMPbfLoader
+
 ## [0.7.2] - 2024-04-20
 
 ### Changed

--- a/srai/loaders/osm_loaders/osm_pbf_loader.py
+++ b/srai/loaders/osm_loaders/osm_pbf_loader.py
@@ -46,7 +46,7 @@ class OSMPbfLoader(OSMLoader):
     def __init__(
         self,
         pbf_file: Optional[Union[str, Path]] = None,
-        download_source: "OsmExtractSource" = "any",
+        download_source: "OsmExtractSource" = "geofabrik",
         download_directory: Union[str, Path] = "files",
     ) -> None:
         """


### PR DESCRIPTION
The other services tend to be unstable so it makes sense to make Geofabrik the default.