### PR TITLE
geometry: remove list comprehensions from `seq(...)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Removed a list comprehension in geometry related operations (implemented by [@ebonnal](https://github.com/ebonnal)).
+
 ## [0.7.7] - 2024-09-25
 
 ### Changed

--- a/srai/geometry.py
+++ b/srai/geometry.py
@@ -25,7 +25,7 @@ __all__ = [
 def flatten_geometry_series(geometry_series: gpd.GeoSeries) -> list[BaseGeometry]:
     """Flatten all geometries from a series into a list of BaseGeometries."""
     geometries: list[BaseGeometry] = (
-        seq([flatten_geometry(geometry) for geometry in geometry_series]).flatten().to_list()
+        seq(geometry_series).flat_map(flatten_geometry).to_list()
     )
     return geometries
 
@@ -34,7 +34,7 @@ def flatten_geometry(geometry: BaseGeometry) -> list[BaseGeometry]:
     """Flatten all geometries into a list of BaseGeometries."""
     if isinstance(geometry, BaseMultipartGeometry):
         geometries: list[BaseGeometry] = (
-            seq([flatten_geometry(sub_geom) for sub_geom in geometry.geoms]).flatten().to_list()
+            seq(geometry.geoms).flat_map(flatten_geometry).to_list()
         )
         return geometries
     return [geometry]


### PR DESCRIPTION
Minor readability improvement removing unecessary list comprehensions and leveraging `seq.flat_map`.